### PR TITLE
metatx-related-contracts 追加

### DIFF
--- a/metatx-related-contracts/ERC2771Context.sol
+++ b/metatx-related-contracts/ERC2771Context.sol
@@ -46,11 +46,11 @@ abstract contract ERC2771Context is Context {
             // The assembly code is more direct than the Solidity version using `abi.decode`.
             /// @solidity memory-safe-assembly
             assembly {
-                // forwarderのexecuteでabi.encodePacked(req.data, req.from)しているので、msg.dataの最後の20bytesがaddressのデータとして使用される
-                // sub(calldatasize(), 20)でaddressのスタート地点を計算する。
-                // その値をcalldataloadに渡して、そこから32bytesを取り出す。
-                // 32bytesの中身は e36ab9f4cc11bD98753F05943D5394D16B356D6A000000000000000000000000 こんな感じになっているので、
-                // shift right 96bits(32bytes)をして、000000000000000000000000e36ab9f4cc11bD98753F05943D5394D16B356D6A の状態にする。
+                // forwarderのexecuteでabi.encodePacked(req.data, req.from)しているので、msg.dataの最後の20bytes(hexの40文字)がaddressのデータとして使用される
+                // sub(calldatasize(), 20)でaddressのスタート地点を計算する
+                // その値をcalldataloadに渡して、そこから32bytesを取り出す
+                // 32bytesの中身は最初の20bytes以外はデータがなく e36ab9f4cc11bD98753F05943D5394D16B356D6A000000000000000000000000 こんな感じのaddressとpaddingとなっているので、
+                // shift right 96bits(12bytes、hexの24文字)をして、000000000000000000000000e36ab9f4cc11bD98753F05943D5394D16B356D6A の状態にして20bytesのaddress型として取り出せるようにする
                 sender := shr(96, calldataload(sub(calldatasize(), 20)))
             }
         } else {

--- a/metatx-related-contracts/ERC2771Context.sol
+++ b/metatx-related-contracts/ERC2771Context.sol
@@ -1,0 +1,78 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.7.0) (metatx/ERC2771Context.sol)
+
+pragma solidity ^0.8.9;
+
+import "../utils/Context.sol";
+
+// metatxのRecipientContractにあたるContractに継承するコントラクト
+// trustedForwarderからmetatxを受け取るときに使用する
+/**
+ * @dev Context variant with ERC2771 support.
+ */
+abstract contract ERC2771Context is Context {
+    // 悪意のある人がtrustedForwarderを書き換えることを防ぐために、
+    // ownerのみ書き換え可能あるいは書き換え不可能にすることが推奨されている(https://eips.ethereum.org/EIPS/eip-2771)
+    /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+    address private immutable _trustedForwarder;
+
+    /// @custom:oz-upgrades-unsafe-allow constructor
+    constructor(address trustedForwarder) {
+        _trustedForwarder = trustedForwarder;
+    }
+
+    // 引数のforwarder(msg.sender)がtrustedForwarderであることを確認する関数
+    // このcontractがmetatxで実行されるものなのかを外部から判断することは難しいため
+    // 受け取ったtransactionに応じて_msgSender()、_msgData()を適切にoverrideするために使用する
+    function isTrustedForwarder(address forwarder)
+        public
+        view
+        virtual
+        returns (bool)
+    {
+        return forwarder == _trustedForwarder;
+    }
+
+    function _msgSender()
+        internal
+        view
+        virtual
+        override
+        returns (address sender)
+    {
+        if (isTrustedForwarder(msg.sender)) {
+            // trastedForwarderから呼び出された場合は、addressを抽出して、msg.senderの代わりにする
+            // assembly {} はInline Assemblyという機能で、EVMに対して直接命令を書いている
+            // The assembly code is more direct than the Solidity version using `abi.decode`.
+            /// @solidity memory-safe-assembly
+            assembly {
+                // forwarderのexecuteでabi.encodePacked(req.data, req.from)しているので、msg.dataの最後の20bytesがaddressのデータとして使用される
+                // sub(calldatasize(), 20)でaddressのスタート地点を計算する。
+                // その値をcalldataloadに渡して、そこから32bytesを取り出す。
+                // 32bytesの中身は e36ab9f4cc11bD98753F05943D5394D16B356D6A000000000000000000000000 こんな感じになっているので、
+                // shift right 96bits(32bytes)をして、000000000000000000000000e36ab9f4cc11bD98753F05943D5394D16B356D6A の状態にする。
+                sender := shr(96, calldataload(sub(calldatasize(), 20)))
+            }
+        } else {
+            // trastedForwarder以外から呼び出された場合はoverride前のmsg.senderを返す
+            return super._msgSender();
+        }
+    }
+
+    function _msgData()
+        internal
+        view
+        virtual
+        override
+        returns (bytes calldata)
+    {
+        if (isTrustedForwarder(msg.sender)) {
+            // addressを除いたmsg.dataを返す
+            // forwarderのexecuteでabi.encodePacked(req.data, req.from)しているので、msg.dataの最後の20bytesがaddressのデータとして使用される
+            return msg.data[:msg.data.length - 20];
+        } else {
+            // trastedForwarder以外から呼び出された場合はoverride前のmsg.senderを返す
+            return super._msgData();
+        }
+    }
+}

--- a/metatx-related-contracts/MinimalForwarder.sol
+++ b/metatx-related-contracts/MinimalForwarder.sol
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.7.0) (metatx/MinimalForwarder.sol)
+
+pragma solidity ^0.8.0;
+
+import "../utils/cryptography/ECDSA.sol";
+import "../utils/cryptography/draft-EIP712.sol";
+
+// 主にテスト用のコントラクト、実運用するためのforwarderとしては機能が不十分。
+// from address(送信者)の署名とNonceを検証する
+/**
+ * @dev Simple minimal forwarder to be used together with an ERC2771 compatible contract. See {ERC2771Context}.
+ *
+ * MinimalForwarder is mainly meant for testing, as it is missing features to be a good production-ready forwarder. This
+ * contract does not intend to have all the properties that are needed for a sound forwarding system. A fully
+ * functioning forwarding system with good properties requires more complexity. We suggest you look at other projects
+ * such as the GSN which do have the goal of building a system like that.
+ */
+contract MinimalForwarder is EIP712 {
+    // ECDSA署名を復号するためのrecover関数を使えるようにする
+    using ECDSA for bytes32;
+
+    // requestのstructを定義
+    struct ForwardRequest {
+        address from;
+        address to;
+        uint256 value;
+        uint256 gas;
+        uint256 nonce;
+        bytes data;
+    }
+
+    // requestのstructをhash化したも
+    // 署名を復号する際に使用する
+    bytes32 private constant _TYPEHASH =
+        keccak256(
+            "ForwardRequest(address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data)"
+        );
+
+    // signer毎に実行されたtransaction数を保持し、replay attackを防ぐために使用する
+    mapping(address => uint256) private _nonces;
+
+    constructor() EIP712("MinimalForwarder", "0.0.1") {}
+
+    // フロントエンドからrequestを投げる前に、この関数を呼び出して最新のnonceを取得し、requestに含める
+    function getNonce(address from) public view returns (uint256) {
+        return _nonces[from];
+    }
+
+    // signerの署名とnonce値を検証する
+    function verify(ForwardRequest calldata req, bytes calldata signature)
+        public
+        view
+        returns (bool)
+    {
+        address signer = _hashTypedDataV4( // encodeされたEIP712のメッセージのハッシュ値を返す
+            keccak256(
+                abi.encode(
+                    _TYPEHASH,
+                    req.from,
+                    req.to,
+                    req.value,
+                    req.gas,
+                    req.nonce,
+                    keccak256(req.data)
+                )
+            )
+        ).recover(signature); // ハッシュから値から署名者(metatxを実行した人)のアドレスを復号する
+        // reqに含まれるnonceとcontract内で保持しているsignerのnonceが一致している
+        // 且つ、ハッシュ値から復号したsignerとreq.fromが一致していればtrueを返す
+        return _nonces[req.from] == req.nonce && signer == req.from;
+    }
+
+    // 署名を検証して、問題なけば、req.dataに含まれる関数名と引数を使って、関数を実行する
+    function execute(ForwardRequest calldata req, bytes calldata signature)
+        public
+        payable
+        returns (bool, bytes memory)
+    {
+        // 署名、nonceを検証する
+        require(
+            verify(req, signature),
+            "MinimalForwarder: signature does not match request"
+        );
+        // nonceをincrementする
+        _nonces[req.from] = req.nonce + 1;
+
+        // req.dataに含まれる関数名と引数を使って、関数を実行する
+        (bool success, bytes memory returndata) = req.to.call{
+            gas: req.gas,
+            value: req.value
+        }(abi.encodePacked(req.data, req.from)); // req.dataの末尾にreq.fromを追加
+
+        // TODO: リンクの内容にある the 1/64 rule が理解できていません。誰か補足お願いします。
+        // Validate that the relayer has sent enough gas for the call.
+        // See https://ronan.eth.link/blog/ethereum-gas-dangers/
+        if (gasleft() <= req.gas / 63) {
+            // We explicitly trigger invalid opcode to consume all gas and bubble-up the effects, since
+            // neither revert or assert consume all gas since Solidity 0.8.0
+            // https://docs.soliditylang.org/en/v0.8.0/control-structures.html#panic-via-assert-and-error-via-require
+            /// @solidity memory-safe-assembly
+            assembly {
+                invalid()
+            }
+        }
+
+        return (success, returndata);
+    }
+}

--- a/metatx-related-contracts/README.md
+++ b/metatx-related-contracts/README.md
@@ -1,0 +1,96 @@
+# Meta Transaction
+## 目次
+### 1. [はじめに](#1-はじめに-1)
+### 2. [meta transactionとは](#2-meta-transactionとは-1)
+### 3. 対象ファイル
+1. [ERC2771Context.sol](#31-erc2771contextsol)
+2. [draft-EIP712.sol](#31-erc2771contextsol)
+3. [MinimalForwarder.sol](#33-minimalforwardersol)
+### 4. [relayerについて(おまけ)](#4-relayerについておまけ-1)
+
+## 1. はじめに
+ここでは、openzeppelinの[metatx](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/metatx)のディレクトリのファイルとそこにインポートされている主要なファイルについてコードを読み、metatxを理解することを目指します。
+
+このディレクトリ(metatx)の内容は、以下の図1の**forwarder**と**recipient**の範囲となっています。relayerをどのように実現するかは様々な方法がありますが、別途検討する必要があります。
+
+
+READMEでは各ファイルが担うの主な機能を伝え、実装の解説は各ファイルのコメントに任せます。
+
+また、まだ力不足で理解が及んでいない箇所は`TODO`としています。どんどん修正を加えていただけますと幸いです。
+
+## 2. Meta Transactionとは
+一言で言うとユーザーはgas代を支払うことなくtransactionを発行するための仕組みです。具体的にはclientとcontractの間にrelayerを挟み、gas代を肩代わりすることでこの仕組みを実現します。
+
+図1.metatxの流れ
+```mermaid
+sequenceDiagram
+participant client as Client
+participant relayer as Relayer
+participant forwarder as Forwarder Contract
+participant recipient as Recipient Contract
+
+client ->> relayer: signed request(off-chain)
+note over relayer: gas代を肩代わりする
+relayer ->> forwarder: send(req)
+forwarder ->> forwarder: verify(req, signature)
+forwarder ->> recipient: call(req.data, req.from)
+note over recipient: req.fromでmsg.senderをoverrideし<br>clientが実行しているように見せる
+recipient ->> recipient: executeSomeFunction()
+recipient -->> client: eventで関数の実行完了を知らせる
+```
+
+この仕組みを実現しようとした時に、次のような疑問が思い浮かぶと思います。
+- transactionを発行するのがclientではなくなるとsenderの`address`がわからなくなるのではないか？
+- senderが正しいことを証明することはできるのだろうか？
+
+これらの疑問を解決するための仕組みがそれぞれ`ERC2771Context.sol`, `draft-EIP712.sol`に備わっています。
+
+
+※以下でclient, relayer, forwarder, recipientというwordを使用する際は、この図1の内容を指します。
+
+## 3.1 ERC2771Context.sol
+参照元: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/ERC2771Context.sol
+
+こちらのファイルはEIP-2771(https://eips.ethereum.org/EIPS/eip-2771) で定義されている規格の抽象コントラクトです。このコントラクトは上記のrecipientにあたるContractに継承させ使用します。
+
+機能としては主に以下の3つを提供します。
+
+### 1. forwarderがtrustedなものか確認する
+`constructor`でforwaderの`address`をsetし、その値と`msg.sender`が等しいかを`isTrustedForwarder(msg.sender)`で比較する。これにより、trustedなforwarderからのtransactionなのかどうかを判断します。
+
+### 2. _msgSenderを上記の図1のclientのaddressでoverride
+`msg.sender`がtrusted forwarderであれば、clientのaddressを_msgSender()から返します。そうでない場合は、`msg.sender`をそのまま返します。
+
+recipient contractから`_msgSender()`を呼ぶことで、このトランザクションを実行したい人(client)が誰なのかを知ることができます。
+
+### 3. _msgDataを余分なデータを取り除いたデータでoverride
+`msg.sender`がtrusted forwarderであれば、msg.dataから余分なデータ(client address)を取り除いて返します。そうでない場合は、`msg.data`をそのまま返します。
+
+forwarderからrecipientの関数を実行する際にdataの末尾にclientのaddressを付与しているので、元々の純粋なdataはそのaddressを除いたものになります。
+
+
+## 3.2 draft-EIP712.sol
+参照元: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/draft-EIP712.sol
+
+こちらのファイルはEIP-712(https://eips.ethereum.org/EIPS/eip-712) で定義されている規格の抽象コントラクトです。EIP-712は構造体に署名をつけることができる規格です。draft-EIP712.solでは構造体をencodeする機能を提供します。
+
+この際に単純に構造体をencodeするだけだと、異なる2つのDAppが同一の構造体を使用する場合に一方のDAppを対象にした署名付きメッセージが、もう一方でも有効になってしまうということが起こり得ます。そのため、DApp毎に異なるドメイン固有の値を含めてencodeする必要があり、その仕組みを実装しています。
+
+
+## 3.3 MinimalForwarder.sol
+参照元: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/metatx/MinimalForwarder.sol
+
+こちらのファイルはforwarderとして機能するコントラクトです。しかしながらあくまでテスト用という位置付けで、実運用をするためには機能が不十分とされています。
+機能としては主に以下の3つを提供します。
+
+### 1. nonceの管理
+clientの`address`毎にnonceを保持し、関数を実行するたびにincrementします。またnonceを取得するための`getNonce()`を備えており、フロントエンドからに最新のnonceを取得し、requestに含めることができます。これにより、requestのnonceとcontractで保持しているnonceが等しいことを比較することが可能になり、[replay attack](https://medium.com/cypher-core/replay-attack-vulnerability-in-ethereum-smart-contracts-introduced-by-transferproxy-124bf3694e25)を防ぐことができます。
+
+### 2. 署名の検証
+draft-EIP712、[ECDSA](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/ECDSA.sol)の関数を使用し、encodeされたEIP712のメッセージのハッシュ値から取得する署名と、`verify`関数の引数の署名が等しいことを検証します。
+
+### 3. recipientの関数の実行
+署名の検証に成功したら、nonceをincrementし、dataの末尾にclientの`address`を付与して、関数を実行します。
+
+## 4. relayerについて(おまけ)
+OpenZeppelinはdefender(https://defender.openzeppelin.com) というサービスを提供しており、こちらを活用することで簡単に実装することができます。

--- a/metatx-related-contracts/draft-EIP712.sol
+++ b/metatx-related-contracts/draft-EIP712.sol
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.4.1 (utils/cryptography/draft-EIP712.sol)
+
+pragma solidity ^0.8.0;
+
+import "./ECDSA.sol";
+
+// 構造体に対して署名を行うための規格
+/**
+ * @dev https://eips.ethereum.org/EIPS/eip-712[EIP 712] is a standard for hashing and signing of typed structured data.
+ *
+ * The encoding specified in the EIP is very generic, and such a generic implementation in Solidity is not feasible,
+ * thus this contract does not implement the encoding itself. Protocols need to implement the type-specific encoding
+ * they need in their contracts using a combination of `abi.encode` and `keccak256`.
+ *
+ * This contract implements the EIP 712 domain separator ({_domainSeparatorV4}) that is used as part of the encoding
+ * scheme, and the final step of the encoding to obtain the message digest that is then signed via ECDSA
+ * ({_hashTypedDataV4}).
+ *
+ * The implementation of the domain separator was designed to be as efficient as possible while still properly updating
+ * the chain id to protect against replay attacks on an eventual fork of the chain.
+ *
+ * NOTE: This contract implements the version of the encoding known as "v4", as implemented by the JSON RPC method
+ * https://docs.metamask.io/guide/signing-data.html[`eth_signTypedDataV4` in MetaMask].
+ *
+ * _Available since v3.4._
+ */
+abstract contract EIP712 {
+    /* solhint-disable var-name-mixedcase */
+    // Cache the domain separator as an immutable value, but also store the chain id that it corresponds to, in order to
+    // invalidate the cached domain separator if the chain id changes.
+    bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
+    uint256 private immutable _CACHED_CHAIN_ID;
+    address private immutable _CACHED_THIS;
+
+    bytes32 private immutable _HASHED_NAME;
+    bytes32 private immutable _HASHED_VERSION;
+    bytes32 private immutable _TYPE_HASH;
+
+    /* solhint-enable var-name-mixedcase */
+
+    /**
+     * @dev Initializes the domain separator and parameter caches.
+     *
+     * The meaning of `name` and `version` is specified in
+     * https://eips.ethereum.org/EIPS/eip-712#definition-of-domainseparator[EIP 712]:
+     *
+     * - `name`: the user readable name of the signing domain, i.e. the name of the DApp or the protocol.
+     * - `version`: the current major version of the signing domain.
+     *
+     * NOTE: These parameters cannot be changed except through a xref:learn::upgrading-smart-contracts.adoc[smart
+     * contract upgrade].
+     */
+    constructor(string memory name, string memory version) {
+        bytes32 hashedName = keccak256(bytes(name));
+        bytes32 hashedVersion = keccak256(bytes(version));
+        bytes32 typeHash = keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+        _HASHED_NAME = hashedName;
+        _HASHED_VERSION = hashedVersion;
+        _CACHED_CHAIN_ID = block.chainid;
+        _CACHED_DOMAIN_SEPARATOR = _buildDomainSeparator(
+            typeHash,
+            hashedName,
+            hashedVersion
+        );
+        _CACHED_THIS = address(this);
+        _TYPE_HASH = typeHash;
+    }
+
+    // 構造体をencodeするだけだと、異なる2つのDAppが同一の構造体を使用する場合に
+    // 一方のDAppを対象にした署名付きメッセージが、もう一方でも有効になってしまう。
+    // そのため、DApp毎に異なるドメイン固有の値を含めてencodeするために、この関数を使用する。
+    /**
+     * @dev Returns the domain separator for the current chain.
+     */
+    function _domainSeparatorV4() internal view returns (bytes32) {
+        if (
+            address(this) == _CACHED_THIS && block.chainid == _CACHED_CHAIN_ID
+        ) {
+            return _CACHED_DOMAIN_SEPARATOR;
+        } else {
+            return
+                _buildDomainSeparator(
+                    _TYPE_HASH,
+                    _HASHED_NAME,
+                    _HASHED_VERSION
+                );
+        }
+    }
+
+    function _buildDomainSeparator(
+        bytes32 typeHash,
+        bytes32 nameHash,
+        bytes32 versionHash
+    ) private view returns (bytes32) {
+        return
+            keccak256(
+                abi.encode(
+                    typeHash,
+                    nameHash,
+                    versionHash,
+                    block.chainid,
+                    address(this)
+                )
+            );
+    }
+
+    /**
+     * @dev Given an already https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct[hashed struct], this
+     * function returns the hash of the fully encoded EIP712 message for this domain.
+     *
+     * This hash can be used together with {ECDSA-recover} to obtain the signer of a message. For example:
+     *
+     * ```solidity
+     * bytes32 digest = _hashTypedDataV4(keccak256(abi.encode(
+     *     keccak256("Mail(address to,string contents)"),
+     *     mailTo,
+     *     keccak256(bytes(mailContents))
+     * )));
+     * address signer = ECDSA.recover(digest, signature);
+     * ```
+     */
+    function _hashTypedDataV4(bytes32 structHash)
+        internal
+        view
+        virtual
+        returns (bytes32)
+    {
+        return ECDSA.toTypedDataHash(_domainSeparatorV4(), structHash);
+    }
+}


### PR DESCRIPTION
## summary
[contracts/metatx](https://github.com/OpenZeppelin/openzeppelin-contracts/tree/master/contracts/metatx) の内容を追加しました。

一部、自分の力不足のためTODOとしてやり残している箇所がありますが、metatxを理解する上での主要な内容についてはコメントを付けられたと思いますので、PR送らせていただきます。

## 補足
READMEの図1で使用している`mermaid` の記述は、previewでこのように表示されます。

```mermaid
sequenceDiagram
participant client as Client
participant relayer as Relayer
participant forwarder as Forwarder Contract
participant recipient as Recipient Contract
client ->> relayer: signed request(off-chain)
note over relayer: gas代を肩代わりする
relayer ->> forwarder: send(req)
forwarder ->> forwarder: verify(req, signature)
forwarder ->> recipient: call(req.data, req.from)
note over recipient: req.fromでmsg.senderをoverrideし<br>clientが実行しているように見せる
recipient ->> recipient: executeSomeFunction()
recipient -->> client: eventで関数の実行完了を知らせる
```
